### PR TITLE
Update README to utilize a public dir in file mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ Setup Mocha and Chai to run tests on your application in the browser.
 
 ```bash
 behavior-driven-shopping-list
-├── test
-│   └── shopping-list.test.js
+├── public
+│   ├── js
+│   ├── test
+│   │   ├── shopping-list-item.test.js
+│   │   └── shopping-list.test.js
+│   └── test.html
 ├── node_modules
 │   ├── chai
 │   └── mocha
-├── test.html
 ├── README.md
 └── package.json
 ````
@@ -92,15 +95,17 @@ Create implementation files.
 
 ```bash
 behavior-driven-shopping-list
-├── js
-│   ├── shopping-list-item.js
-│   └── shopping-list.js
-├── test
-│   └── shopping-list.test.js
+├── public
+│   ├── js
+│   │   ├── shopping-list-item.js
+│   │   └── shopping-list.js
+│   ├── test
+│   │   ├── shopping-list-item.test.js
+│   │   └── shopping-list.test.js
+│   └── test.html
 ├── node_modules
 │   ├── chai
 │   └── mocha
-├── test.html
 ├── README.md
 └── package.json
 ````
@@ -136,17 +141,19 @@ Create implementation files.
 
 ```bash
 behavior-driven-shopping-list
-├── js
-│   ├── app.js
-│   ├── shopping-list-item.js
-│   └── shopping-list.js
-├── test
-│   └── shopping-list.test.js
+├── public
+│   ├── js
+│   │   ├── app.js
+│   │   ├── shopping-list-item.js
+│   │   └── shopping-list.js
+│   ├── test
+│   │   ├── shopping-list-item.test.js
+│   │   └── shopping-list.test.js
+│   ├── test.html
+│   └── index.html
 ├── node_modules
 │   ├── chai
 │   └── mocha
-├── index.html
-├── test.html
 ├── README.md
 └── package.json
 ````


### PR DESCRIPTION
Updated the file directory example mapping to include a public dir to serve out of rather than using the project root. 